### PR TITLE
fix: parse deployment name from kfuse prompt

### DIFF
--- a/holmes/plugins/toolsets/infrainsights/kfuse_tempo_toolset.py
+++ b/holmes/plugins/toolsets/infrainsights/kfuse_tempo_toolset.py
@@ -2,11 +2,11 @@ import os
 import json
 import logging
 import re
-from datetime import datetime, timedelta
-from typing import Any, Dict, Optional, List
+from datetime import datetime
+from typing import Any, Dict, Optional
 
 import requests
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
 from holmes.core.tools import (
     Tool,
     ToolParameter,
@@ -80,30 +80,30 @@ class PromptParser:
             
         # Enhanced patterns following InfraInsights conventions
         patterns = [
-            # Specific name patterns with colons (highest priority)
-            r'deployment:\s*([a-zA-Z0-9\-_]+)',
-            r'service:\s*([a-zA-Z0-9\-_]+)',
-            r'pod:\s*([a-zA-Z0-9\-_]+)',
-            r'workload:\s*([a-zA-Z0-9\-_]+)',
-            r'container:\s*([a-zA-Z0-9\-_]+)',
-            
+            # Specific name patterns with keyword first (highest priority)
+            r'deployment[:\s]+["\']?([a-zA-Z0-9\-_]+)["\']?',
+            r'service[:\s]+["\']?([a-zA-Z0-9\-_]+)["\']?',
+            r'pod[:\s]+["\']?([a-zA-Z0-9\-_]+)["\']?',
+            r'workload[:\s]+["\']?([a-zA-Z0-9\-_]+)["\']?',
+            r'container[:\s]+["\']?([a-zA-Z0-9\-_]+)["\']?',
+
             # Direct mentions with resource types
             r'([a-zA-Z0-9\-_]+)\s+deployment',
             r'([a-zA-Z0-9\-_]+)\s+service',
             r'([a-zA-Z0-9\-_]+)\s+pod',
             r'([a-zA-Z0-9\-_]+)\s+workload',
             r'([a-zA-Z0-9\-_]+)\s+container',
-            
+
             # "for" patterns
             r'for\s+([a-zA-Z0-9\-_]+)(?:\s+(?:deployment|service|pod|workload))?',
             r'traces?\s+for\s+([a-zA-Z0-9\-_]+)',
             r'logs?\s+for\s+([a-zA-Z0-9\-_]+)',
-            
+
             # Service name patterns
             r'([a-zA-Z0-9\-_]+)-service',
             r'([a-zA-Z0-9\-_]+)-api',
             r'([a-zA-Z0-9\-_]+)-app',
-            
+
             # Generic patterns (lower priority)
             r'([a-zA-Z0-9\-_]+)\s+traces',
             r'([a-zA-Z0-9\-_]+)\s+logs',
@@ -115,7 +115,7 @@ class PromptParser:
             if match:
                 extracted = match.group(1)
                 # Skip common false positives
-                if extracted.lower() in ['deployment', 'service', 'pod', 'workload', 'container', 'traces', 'logs', 'for', 'in', 'from']:
+                if extracted.lower() in ['deployment', 'service', 'pod', 'workload', 'container', 'traces', 'logs', 'for', 'in', 'from', 'get', 'show', 'fetch', 'display', 'retrieve', 'list']:
                     continue
                 return extracted
         

--- a/tests/test_prompt_parser.py
+++ b/tests/test_prompt_parser.py
@@ -1,0 +1,20 @@
+import importlib.util
+import pathlib
+
+
+def load_prompt_parser():
+    spec = importlib.util.spec_from_file_location(
+        "tempo_toolset", pathlib.Path("holmes/plugins/toolsets/infrainsights/kfuse_tempo_toolset.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.PromptParser
+
+
+def test_extract_kube_deployment_after_keyword():
+    PromptParser = load_prompt_parser()
+    prompt = (
+        'Get traces for deployment "arkham" in namespace "mt-prod" '
+        'from the last 1 hour to analyze slow API responses.'
+    )
+    assert PromptParser.extract_kube_deployment(prompt) == "arkham"


### PR DESCRIPTION
## Summary
- handle deployment keyword parsing so "Get traces for deployment X" resolves to X
- add regression test for deployment name extraction in PromptParser

## Testing
- `ruff check holmes/plugins/toolsets/infrainsights/kfuse_tempo_toolset.py tests/test_prompt_parser.py`
- `pytest --no-cov tests/test_prompt_parser.py`
- `pytest --no-cov --maxfail=1` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b014ab99c48320bd389e7928b640a2