### PR TITLE
Refine Kfuse Tempo query handling

### DIFF
--- a/tests/test_prompt_parser.py
+++ b/tests/test_prompt_parser.py
@@ -18,3 +18,9 @@ def test_extract_kube_deployment_after_keyword():
         'from the last 1 hour to analyze slow API responses.'
     )
     assert PromptParser.extract_kube_deployment(prompt) == "arkham"
+
+
+def test_extract_service_name():
+    PromptParser = load_prompt_parser()
+    prompt = 'Fetch traces for service checkout in namespace payments'
+    assert PromptParser.extract_service_name(prompt) == "checkout"


### PR DESCRIPTION
## Summary
- add service name extraction to Kfuse Tempo parser
- query Kfuse Tempo using service/namespace filters and proper headers
- document basic auth and auth user config

## Testing
- `pytest tests/test_prompt_parser.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68b15d4bc5088320833d39656a1f6fc2